### PR TITLE
Re-adding the trivia command following the new architecture + UT

### DIFF
--- a/botquery.py
+++ b/botquery.py
@@ -28,6 +28,8 @@ class BotQuery:
                 result.is_edited = True
                 
             result.message = data.get(msg_key, empty).get(TEXT_KEY)
+            result.message_id = data.get(msg_key, empty).get(MESSAGE_ID_KEY)
+            result.callback_data = data.get(DATA_KEY)
             result.chat_id = data.get(msg_key, empty).get(CHAT_KEY, empty).get(ID_KEY)
             result.chat_title = data.get(msg_key, empty).get(CHAT_KEY, empty).get(TITLE_KEY)
             result.from_id = data.get(msg_key, empty).get(FROM_KEY, empty).get(ID_KEY)
@@ -61,9 +63,11 @@ class BotQuery:
         # Callback query
         self.has_callback_query = False
         self.callback_query = None
+        self.callback_data = None
 
         # Message content
         self.message = None
+        self.message_id = None
         self.chat_id = None
         self.from_id = None
         self.user_first_name = None

--- a/commands/botcommand.py
+++ b/commands/botcommand.py
@@ -4,8 +4,9 @@ import requests
 
 # This class defines the base class that all commands for the bot must inherit from
 class BotCommand:
-    def __init__(self, query):
+    def __init__(self, query, command_arguments=None):
         self.query = query
+        self.command_arguments = command_arguments
         self.ignore_edited = True
         self.response_json = None
 

--- a/commands/command_parser.py
+++ b/commands/command_parser.py
@@ -20,9 +20,13 @@ class CommandParser:
     
     @classmethod
     def parse_command(cls, bot_query: BotQuery) -> BotCommand:
+        if bot_query.has_callback_query:
+            cmd_name = bot_query.callback_query.callback_data.rsplit('/')[-1].lower()
+            return AVAILABLE_COMMANDS[cmd_name](bot_query) if cmd_name in AVAILABLE_COMMANDS else InvalidCommand(bot_query)
+
         args = str(bot_query.message).strip().split()
         cmd_name = args[0].lower() if len(args) > 0 else ""
 
         if cmd_name.startswith("/") and cmd_name[1:] in AVAILABLE_COMMANDS:
-            return AVAILABLE_COMMANDS[cmd_name[1:]](bot_query)
-        return InvalidCommand(bot_query)
+            return AVAILABLE_COMMANDS[cmd_name[1:]](bot_query, args)
+        return InvalidCommand(bot_query, args)

--- a/commands/command_parser.py
+++ b/commands/command_parser.py
@@ -6,6 +6,7 @@ from .fact_command import FactCommand
 from .trivia_command import TriviaCommand
 from .invalid_command import InvalidCommand
 from botquery import BotQuery
+from shlex import split as sh_split
 
 # This indicates the acceptable commands
 AVAILABLE_COMMANDS = {
@@ -21,12 +22,19 @@ class CommandParser:
     @classmethod
     def parse_command(cls, bot_query: BotQuery) -> BotCommand:
         if bot_query.has_callback_query:
+
+            # Parses the command at the end of the callback payload by design
+            # eg. "Payload_data/trivia" will be parsed as a trivia command
             cmd_name = bot_query.callback_query.callback_data.rsplit('/')[-1].lower()
-            return AVAILABLE_COMMANDS[cmd_name](bot_query) if cmd_name in AVAILABLE_COMMANDS else InvalidCommand(bot_query)
+            if cmd_name in AVAILABLE_COMMANDS:
+                return AVAILABLE_COMMANDS[cmd_name](bot_query)
+            return InvalidCommand(bot_query)
 
-        args = str(bot_query.message).strip().split()
-        cmd_name = args[0].lower() if len(args) > 0 else ""
+        args = sh_split(str(bot_query.message))
+        
+        cmd_arg = args[0].lower() if len(args) > 0 else ""
+        cmd_name = cmd_arg[1:] if len(cmd_arg) > 0 else ""
 
-        if cmd_name.startswith("/") and cmd_name[1:] in AVAILABLE_COMMANDS:
-            return AVAILABLE_COMMANDS[cmd_name[1:]](bot_query, args)
+        if cmd_arg.startswith("/") and cmd_name in AVAILABLE_COMMANDS:
+            return AVAILABLE_COMMANDS[cmd_name](bot_query, args)
         return InvalidCommand(bot_query, args)

--- a/commands/fact_command.py
+++ b/commands/fact_command.py
@@ -1,6 +1,6 @@
 import requests
 
-from constants import *
+from constants import PARSE_MODE_KEY
 from .botcommand import BotCommand
 from boterror import BotError
 from botquery import BotQuery

--- a/commands/trivia_command.py
+++ b/commands/trivia_command.py
@@ -1,15 +1,88 @@
 import requests
 
+from constants import PARSE_MODE_KEY, EDIT_MESSAGE_ENDPOINT
+from config import BASE_URL
 from .botcommand import BotCommand
 from boterror import BotError
 from botquery import BotQuery
+from trivia import Trivia, TRIVIA_BASE_ERROR_MESSAGE
 
 class TriviaCommand(BotCommand):
+    def __init__(self, query, command_arguments=None):
+        super().__init__(query, command_arguments)
+        self.trivia = None
+
     def execute(self):
-        pass
+        if self.query.has_callback_query:
+            self.handle_callback_query()
+            return
+        category, difficulty = None, None
+
+        if len(self.command_arguments) > 1:
+            category = self.command_arguments[1]
+            if category.lower() == "help":
+                self.handle_normal_query(Trivia.get_help_text())
+                return
+                
+            if len(self.command_arguments) > 2:
+                difficulty = self.command_arguments[2]
+
+        try:
+            self.trivia = Trivia.fetch_question(category, difficulty)
+        except BotError as bot_err:
+            print(f"TriviaCommand Error (Checked):\n\t{bot_err}")
+            self.handle_normal_query(str(bot_err))
+        except Exception as err:
+            print(f"TriviaCommand Error (Unchecked):\n\t{err}")
+            self.handle_normal_query(str(err))
+        else:
+            self.handle_normal_query(self.trivia.formatted_response())
+    
+    def format_response_json(self):
+        self.response_json[PARSE_MODE_KEY] = "Markdown"
+
+        if not self.trivia:
+            return
+
+        correct_ans = chr(self.trivia.correct_answer_index() + 65)
+        buttons = [ {"text": chr(i+65), "callback_data": f"{chr(i+65)}{correct_ans}/trivia" } for i in range(4) ]
+
+        self.response_json["reply_markup"] = {
+            "inline_keyboard": [
+                [
+                    buttons[0],
+                    buttons[1]
+                ],
+                [
+                    buttons[2],
+                    buttons[3]
+                ]
+            ]
+        }
 
     def handle_callback_query(self):
-        pass
+        try:
+            given_answer = self.query.callback_query.callback_data[0]
+            correct_answer = self.query.callback_query.callback_data[1]
+            if given_answer == correct_answer:
+                result_text = f"*{given_answer}* is correct!"
+            else:
+                result_text = f"*{given_answer}* is incorrect! The correct answer is *{correct_answer}*"
+        except Exception as err:
+            print(f"Error occured while handling trivia callback\n\t{err}")
+            return
 
-    def format_response_json(self, response_json):
-        pass
+        url = f"{BASE_URL}/{EDIT_MESSAGE_ENDPOINT}"
+        response_json = {
+            "chat_id": self.query.callback_query.chat_id,
+            "message_id": self.query.callback_query.message_id,
+            "text": f"{self.query.callback_query.message}\n\n{result_text}",
+            "reply_markup": {
+                "inline_keyboard": [],
+            },
+            "parse_mode": "Markdown"
+        }
+
+        response = requests.post(url, json=response_json)
+        if not response.ok:
+            print(f"Error occured while sending trivia results back\n\t{response.text}")

--- a/constants.py
+++ b/constants.py
@@ -3,6 +3,8 @@ INLINE_QUERY_KEY = "inline_query"
 CALLBACK_QUERY_KEY = "callback_query"
 EDITED_MESSAGE_KEY = "edited_message"
 MESSAGE_KEY = "message"
+MESSAGE_ID_KEY = "message_id"
+DATA_KEY = "data"
 ID_KEY = "id"
 CHAT_ID_KEY = "chat_id"
 QUERY_KEY = "query"
@@ -20,3 +22,4 @@ PRIVATE_STR = "private"
 
 # API endpoints
 SEND_MESSAGE_ENDPOINT = "sendMessage"
+EDIT_MESSAGE_ENDPOINT = "editMessageText"

--- a/constants.py
+++ b/constants.py
@@ -23,3 +23,6 @@ PRIVATE_STR = "private"
 # API endpoints
 SEND_MESSAGE_ENDPOINT = "sendMessage"
 EDIT_MESSAGE_ENDPOINT = "editMessageText"
+
+# Other
+ASCII_ALPHABET_OFFSET = 65

--- a/test/botquery_test.py
+++ b/test/botquery_test.py
@@ -246,6 +246,7 @@ class BotQueryTest(unittest.TestCase):
         self.assertIsNotNone(query.callback_query, "There should be a callback query property!")
 
         callback_query = query.callback_query
+        self.assertEqual(callback_query.callback_data, "DD")
         self.assertFalse(callback_query.is_private, "is_private is wrong!")
         self.assertTrue(callback_query.is_group, "is_group is wrong!")
         self.assertFalse(callback_query.is_edited, "is_edited is wrong!")

--- a/test/command_parser_test.py
+++ b/test/command_parser_test.py
@@ -45,6 +45,16 @@ class CommandParserTest(unittest.TestCase):
         result = CommandParser.parse_command(query)
         self.assertIsInstance(result, TriviaCommand)
         self.assertIs(query, result.query)
+    
+    def test_trivia_command_callback(self):
+        query = BotQuery()
+        query.has_callback_query = True
+        query.callback_query = BotQuery()
+        query.callback_query.callback_data = "payload here/trivia"
+
+        result = CommandParser.parse_command(query)
+        self.assertIsInstance(result, TriviaCommand)
+        self.assertIs(query, result.query)
 
     def test_empty_command(self):
         query = BotQuery()

--- a/test/trivia_command_test.py
+++ b/test/trivia_command_test.py
@@ -1,5 +1,212 @@
 import unittest, setup
 
-class TrivaTest(unittest.TestCase):
-    def test_test(self):
-        self.assertEqual(True, True, "Wrong!")
+from unittest.mock import patch, Mock
+
+from trivia import Trivia
+from commands.trivia_command import TriviaCommand
+from commands.botcommand import BotCommand
+from botquery import BotQuery
+from boterror import BotError
+
+class TriviaCommandTest(unittest.TestCase):
+    def test_trivia_get_category_dict(self):
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: {"cat1": 1, "cat2:": 2}
+            self.assertEqual(Trivia.category_dict, dict())
+
+            # Fetch categories
+            Trivia.get_category_dict()
+            self.assertEqual(Trivia.category_dict, {"cat1": 1, "cat2:": 2})
+
+            # Already fetched
+            Trivia.get_category_dict()
+            self.assertEqual(Trivia.category_dict, {"cat1": 1, "cat2:": 2})
+
+    def test_trivia_get_category_id_valid(self):
+        return_val = {
+            "trivia_categories": [
+                {
+                    "name": "cat1",
+                    "id": 1
+                },
+                {
+                    "name": "cat2",
+                    "id": 2
+                },
+                {
+                    "name": "cat3",
+                    "id": 3
+                }
+            ]
+        }
+
+        with patch("trivia.Trivia.get_category_dict", return_value=return_val) as mock_dict:
+            self.assertEqual(Trivia.get_category_id("cat1"), 1)
+            self.assertEqual(Trivia.get_category_id("cat2"), 2)
+            self.assertEqual(Trivia.get_category_id("cat3"), 3)
+            self.assertEqual(Trivia.get_category_id("cAT1  "), 1)
+            self.assertEqual(Trivia.get_category_id("  CaT2"), 2)
+            self.assertEqual(Trivia.get_category_id("   cAt3   "), 3)
+
+            self.assertEqual(Trivia.get_category_id("Any"), 0)
+            self.assertEqual(Trivia.get_category_id(None), 0)
+            self.assertEqual(Trivia.get_category_id(""), 0)
+            
+    def test_trivia_get_category_id_invalid(self):
+        return_val = {
+            "trivia_categories": [
+                {
+                    "name": "science",
+                    "id": 1
+                }
+            ]
+        }
+
+        with patch("trivia.Trivia.get_category_dict", return_value=return_val) as mock_dict:
+            self.assertEqual(Trivia.get_category_id("Science"), 1)
+            self.assertRaises(BotError, Trivia.get_category_id, "bad")
+
+    def test_trivia_fetch_question_valid(self):
+        question_json = {
+            "response_code":0,
+            "results":[
+                {
+                    "category":"cat1",
+                    "type":"multiple",
+                    "difficulty":"easy",
+                    "question":"What is the first letter of the alphabet?",
+                    "correct_answer":"A",
+                    "incorrect_answers":[
+                        "D",
+                        "C",
+                        "B"
+                    ]
+                }
+            ]
+        }
+
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: question_json
+
+            question = Trivia.fetch_question()
+            self.assertEqual(question.category, "cat1")
+            self.assertEqual(question.type, "multiple")
+            self.assertEqual(question.difficulty, "easy")
+            self.assertEqual(question.question, "What is the first letter of the alphabet?")
+            self.assertEqual(question.correct_answer, "A")
+            self.assertListEqual(question.answers, ["A", "B", "C", "D"])
+
+    @patch("trivia.print")
+    def test_trivia_fetch_question_invalid_not_ok(self, _):
+        question_json = {
+            "response_code":1,
+            "results":[]
+        }
+
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = False
+            self.assertRaises(BotError, Trivia.fetch_question)
+
+    @patch("trivia.print")
+    def test_trivia_fetch_question_invalid_bad_json(self, _):
+        question_json_1 = dict()
+
+        question_json_2 = {
+            "response_code":1,
+            "results":[]
+        }
+
+        question_json_3 = {
+            "response_code":0,
+        }
+
+        question_json_4 = {
+            "response_code":0,
+            "results":[]
+        }
+
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: question_json_1
+            self.assertRaises(BotError, Trivia.fetch_question)
+    
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: question_json_2
+            self.assertRaises(BotError, Trivia.fetch_question)
+
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: question_json_3
+            self.assertRaises(BotError, Trivia.fetch_question)
+
+        with patch("trivia.requests.get") as mock_get:
+            mock_get.return_value.ok = True
+            mock_get.return_value.json = lambda: question_json_4
+            self.assertRaises(BotError, Trivia.fetch_question)
+  
+    def test_trivia_help_text(self):
+        query = BotQuery()
+        trivia_command = TriviaCommand(query, ["/trivia", "help"])
+
+        with patch("trivia.Trivia.get_help_text", return_value="help text"):
+            trivia_command.handle_normal_query = Mock() 
+            trivia_command.execute()
+            trivia_command.handle_normal_query.assert_called_once_with("help text")
+
+    def test_trivia_fetch_question_success(self):
+        query = BotQuery()
+        trivia_command = TriviaCommand(query, ["/trivia"])
+        trivia_mock = Trivia()
+        trivia_mock.formatted_response = lambda: "trivia question"
+
+        with patch("trivia.Trivia.fetch_question", return_value=trivia_mock):
+            trivia_command.handle_normal_query = Mock() 
+            trivia_command.execute()
+            trivia_command.handle_normal_query.assert_called_once_with("trivia question")
+
+    @patch("commands.trivia_command.print")
+    def test_trivia_fetch_question_fail(self, _):
+        query = BotQuery()
+        trivia_command = TriviaCommand(query, ["/trivia"])
+
+        with patch("trivia.Trivia.fetch_question", side_effect=Exception("trivia error")):
+            trivia_command.handle_normal_query = Mock() 
+            trivia_command.execute()
+            trivia_command.handle_normal_query.assert_called_once_with("trivia error")
+
+    def test_trivia_callback_query(self):
+        query = BotQuery()
+        query.has_callback_query = True
+
+        trivia_command = TriviaCommand(query)
+        trivia_command.handle_callback_query = Mock()
+
+        trivia_command.execute()
+        trivia_command.handle_callback_query.assert_called_once()
+
+    def test_trivia_callback_query_incorrect(self):
+        query = BotQuery()
+        query.has_callback_query = True
+        query.callback_query = BotQuery()
+        query.callback_query.callback_data = "AD/trivia"
+        trivia_command = TriviaCommand(query)
+
+        with patch("commands.trivia_command.requests.post") as mock_post:
+            trivia_command.execute()
+            response_text = mock_post.call_args[1]["json"]["text"]
+            self.assertTrue(response_text.endswith("*A* is incorrect! The correct answer is *D*"))
+
+    def test_trivia_callback_query_correct(self):
+        query = BotQuery()
+        query.has_callback_query = True
+        query.callback_query = BotQuery()
+        query.callback_query.callback_data = "CC/trivia"
+        trivia_command = TriviaCommand(query)
+
+        with patch("commands.trivia_command.requests.post") as mock_post:
+            trivia_command.execute()
+            response_text = mock_post.call_args[1]["json"]["text"]
+            self.assertTrue(response_text.endswith("*C* is correct!"))

--- a/test/trivia_command_test.py
+++ b/test/trivia_command_test.py
@@ -45,9 +45,9 @@ class TriviaCommandTest(unittest.TestCase):
             self.assertEqual(Trivia.get_category_id("cat1"), 1)
             self.assertEqual(Trivia.get_category_id("cat2"), 2)
             self.assertEqual(Trivia.get_category_id("cat3"), 3)
-            self.assertEqual(Trivia.get_category_id("cAT1  "), 1)
-            self.assertEqual(Trivia.get_category_id("  CaT2"), 2)
-            self.assertEqual(Trivia.get_category_id("   cAt3   "), 3)
+            self.assertEqual(Trivia.get_category_id("cAT1"), 1)
+            self.assertEqual(Trivia.get_category_id("CaT2"), 2)
+            self.assertEqual(Trivia.get_category_id("cAt3"), 3)
 
             self.assertEqual(Trivia.get_category_id("Any"), 0)
             self.assertEqual(Trivia.get_category_id(None), 0)
@@ -168,14 +168,24 @@ class TriviaCommandTest(unittest.TestCase):
             trivia_command.handle_normal_query.assert_called_once_with("trivia question")
 
     @patch("commands.trivia_command.print")
-    def test_trivia_fetch_question_fail(self, _):
+    def test_trivia_fetch_question_fail_boterror(self, _):
+        query = BotQuery()
+        trivia_command = TriviaCommand(query, ["/trivia"])
+
+        with patch("trivia.Trivia.fetch_question", side_effect=BotError("trivia error")):
+            trivia_command.handle_normal_query = Mock() 
+            trivia_command.execute()
+            trivia_command.handle_normal_query.assert_called_once_with("trivia error")
+    
+    @patch("commands.trivia_command.print")
+    def test_trivia_fetch_question_fail_unhandled_error(self, _):
         query = BotQuery()
         trivia_command = TriviaCommand(query, ["/trivia"])
 
         with patch("trivia.Trivia.fetch_question", side_effect=Exception("trivia error")):
             trivia_command.handle_normal_query = Mock() 
             trivia_command.execute()
-            trivia_command.handle_normal_query.assert_called_once_with("trivia error")
+            trivia_command.handle_normal_query.assert_called_once_with("Failed to fetch trivia question!")
 
     def test_trivia_callback_query(self):
         query = BotQuery()

--- a/trivia.py
+++ b/trivia.py
@@ -23,30 +23,45 @@ class Trivia:
                 print(f"Failed to fetch trivia categories\n\t{str(err)}")
         return cls.category_dict
 
+    """Formats the help text string as the usage text, list of categories and difficulties in different sections"""
     @classmethod
     def get_help_text(cls) -> str:
-        category_list = [("\* " + item["name"]) for item in (cls.get_category_dict().get("trivia_categories", []))]
-        difficulty_list = [("\* " + item.capitalize()) for item in cls.difficulty_list]
+
+        # command usage text
+        usage_text = "/trivia [ <category> | any ] [ <difficulty> | any ]"
+
+        # creates list of categories prepended by '*' for visuals
+        category_list = [(f"\* {item['name']}") for item in (cls.get_category_dict().get("trivia_categories", []))]
+
+        # creates list of difficulties, with the first letter capiticalized, prepended by '*' for visuals
+        difficulty_list = [(f"\* {item.capitalize()}") for item in cls.difficulty_list]
         nl = '\n'
-        return f"Usage: */trivia [category] [difficulty]*\n\n*Categories:*\n{nl.join(category_list)}\n\n*Difficulties:*\n{nl.join(difficulty_list)}"
+        return f"Usage:\n*{usage_text}*\n\n*Categories:*\n{nl.join(category_list)}\n\n*Difficulties:*\n{nl.join(difficulty_list)}"
 
     @classmethod
     def get_category_id(cls, category_name: str) -> int:
-        if not category_name or category_name.lower() == "any":
+        if not category_name:
             return 0
-        
-        category_lower = category_name.lower()
+
+        category_name_lower = category_name.lower()
+        if category_name_lower == "any":
+            return 0
 
         for category in cls.get_category_dict().get("trivia_categories", []):
             name = category["name"].lower()
-            if category_name.lower().strip() in name:
+            if category_name_lower in name:
                 return int(category["id"])
         raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE} No category associated with '{category_name}'")
     
     @classmethod
     def get_difficulty(cls, difficulty: str) -> str:
-        if not difficulty or difficulty.lower() == "any": return None
+        if not difficulty:
+            return None
+
         difficulty_lower = difficulty.lower()
+        if difficulty_lower == "any":
+            return None
+        
         if difficulty_lower not in cls.difficulty_list:
             raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE} No difficulty associated with '{difficulty}'")
         return difficulty_lower

--- a/trivia.py
+++ b/trivia.py
@@ -3,49 +3,58 @@ from boterror import BotError
 
 import requests
 
-TRIVIA_BASE_URL = "https://opentdb.com/"
+TRIVIA_BASE_URL = "https://opentdb.com"
 TRIVIA_BASE_ERROR_MESSAGE = "Failed to fetch trivia question!"
-
-def fetchCategories():
-    res = requests.get(TRIVIA_BASE_URL + "api_category.php")
-    if not res.ok:
-        return dict()
-    return res.json()
+RESPONSE_CODE_STR = "response_code"
+RESULTS_STR = "results"
 
 class Trivia:
-    category_dict = fetchCategories()
+    category_dict = dict()
     difficulty_list = ["easy", "medium", "hard"]
 
     @classmethod
-    def getHelpText(cls) -> str:
-        category_list = [("\* " + item["name"]) for item in (cls.category_dict.get("trivia_categories") or [])]
-        difficulty_list = [("\* " + item.capitalize()) for item in cls.difficulty_list]
-        return "Usage: */trivia [category] [difficulty]*\n\n*Categories:*\n{}\n\n*Difficulties:*\n{}".format("\n".join(category_list), "\n".join(difficulty_list))
+    def get_category_dict(cls):
+        if not cls.category_dict:
+            try:
+                res = requests.get(f"{TRIVIA_BASE_URL}/api_category.php")
+                if res.ok:
+                    cls.category_dict = res.json()
+            except Exception as err:
+                print(f"Failed to fetch trivia categories\n\t{str(err)}")
+        return cls.category_dict
 
     @classmethod
-    def getCategoryId(cls, category_name: str) -> int:
-        if not category_name or category_name.lower() == "any": return 0
-        category_lower = category_name.lower()
-        if category_lower == "help":
-            raise BotError(cls.getHelpText())
+    def get_help_text(cls) -> str:
+        category_list = [("\* " + item["name"]) for item in (cls.get_category_dict().get("trivia_categories", []))]
+        difficulty_list = [("\* " + item.capitalize()) for item in cls.difficulty_list]
+        nl = '\n'
+        return f"Usage: */trivia [category] [difficulty]*\n\n*Categories:*\n{nl.join(category_list)}\n\n*Difficulties:*\n{nl.join(difficulty_list)}"
 
-        for category in cls.category_dict.get("trivia_categories") or []:
+    @classmethod
+    def get_category_id(cls, category_name: str) -> int:
+        if not category_name or category_name.lower() == "any":
+            return 0
+        
+        category_lower = category_name.lower()
+
+        for category in cls.get_category_dict().get("trivia_categories", []):
             name = category["name"].lower()
             if category_name.lower().strip() in name:
                 return int(category["id"])
-        raise BotError("{} No category associated with '{}'".format(TRIVIA_BASE_ERROR_MESSAGE, category_name))
+        raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE} No category associated with '{category_name}'")
     
     @classmethod
-    def getDifficulty(cls, difficulty: str) -> str:
+    def get_difficulty(cls, difficulty: str) -> str:
         if not difficulty or difficulty.lower() == "any": return None
-        difficulty = difficulty.lower()
-        if difficulty not in cls.difficulty_list:
-            raise BotError("{} No difficulty associated with '{}'".format(TRIVIA_BASE_ERROR_MESSAGE, difficulty))
-        return difficulty
+        difficulty_lower = difficulty.lower()
+        if difficulty_lower not in cls.difficulty_list:
+            raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE} No difficulty associated with '{difficulty}'")
+        return difficulty_lower
 
-    def __init__(self, category, difficulty):
-        category_id = self.getCategoryId(category)
-        difficulty = self.getDifficulty(difficulty)
+    @classmethod
+    def fetch_question(cls, category=None, difficulty=None):
+        category_id = cls.get_category_id(category)
+        difficulty = cls.get_difficulty(difficulty)
 
         params = {
             "amount": 1,
@@ -58,37 +67,51 @@ class Trivia:
         if difficulty:
             params["difficulty"] = difficulty
         
-        r = requests.get("https://opentdb.com/api.php", params=params)
-        if not r.ok:
-            raise BotError(TRIVIA_BASE_ERROR_MESSAGE)
-        
-        json_response = r.json()
-        if json_response["response_code"] != 0:
-            raise BotError(TRIVIA_BASE_ERROR_MESSAGE)
+        try:
+            response = requests.get(f"{TRIVIA_BASE_URL}/api.php", params=params)
+            if not response.ok:
+                print("Trivia API call did not give an ok (200) response")
+                raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE}")
+            
+            json_response = response.json()
+            if RESPONSE_CODE_STR not in json_response or json_response[RESPONSE_CODE_STR] != 0 or \
+                RESULTS_STR not in json_response or len(json_response[RESULTS_STR]) == 0:
+                print("Invalid trivia json response, parsing aborted")
+                raise BotError(f"{TRIVIA_BASE_ERROR_MESSAGE}")
+            
+            response = json_response[RESULTS_STR][0]
 
-        r = json_response["results"][0]
-        self.category = unescape(r["category"])
-        self.type = unescape(r["type"])
-        self.difficulty = unescape(r["difficulty"])
-        self.question = unescape(r["question"])
-        self.correct_answer = unescape(r["correct_answer"])
-        self.answers = list(map(lambda item: unescape(item), r["incorrect_answers"]))
-        self.answers.append(self.correct_answer)
-        self.answers.sort()
+            result = Trivia()
+            result.category = unescape(response["category"])
+            result.type = unescape(response["type"])
+            result.difficulty = unescape(response["difficulty"])
+            result.question = unescape(response["question"])
+            result.correct_answer = unescape(response["correct_answer"])
+            result.answers = list(map(lambda item: unescape(item), response["incorrect_answers"]))
+            result.answers.append(result.correct_answer)
+            result.answers.sort()
 
-    def question(self):
-        return self.question
+            return result
 
-    def answers(self):
-        return self.answers
+        except Exception as err:
+            print(f"Trivia fetchQuestion error\n\t{str(err)}")
+            raise BotError(err)
+    
+    def __init__(self):
+        self.category = None
+        self.type = None
+        self.difficulty = None
+        self.question = None
+        self.correct_answer = None
+        self.answers = None
 
     def formatted_response(self):
         offset = 65
-        res = "*Category* - {}\n".format(self.category)
-        res += "*Difficulty* - {}\n\n".format(self.difficulty.capitalize())
-        res += "_{}_\n\n".format(self.question)
+        res = f"*Category* - {self.category}\n"
+        res += f"*Difficulty* - {self.difficulty.capitalize()}\n\n"
+        res += f"_{self.question}_\n\n"
         for i, ans in enumerate(self.answers):
-            res += "{}. {}\n".format(chr(i + offset), ans)
+            res += f"{chr(i + offset)}. {ans}\n"
         return res
 
     def correct_answer_index(self):


### PR DESCRIPTION
Usage:
- `/trivia help` to see the help message associated with the trivia interface
- `/trivia [ <category> | any ] [ <difficulty> | any ]` to fetch a random question from a specified category and difficulty, or `any` for a randomized flag. Available categories and difficulty are displayed from the trivia help command. If omitted, it will default to "any"