### PR TITLE
Fix dependencies to be compatible with lambda and modify deployment pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,10 @@ python:
   - "3.7"
 before_install:
 install:
-  - pip install -r requirements.txt -t vendored
+  - pip install -r requirements-ci.txt -t vendored
 before_script:
   - python handler.py
 script:
   - ./test/pytest
 after_success:
-  - "./ci/deploy"
 after_failure:
-deploy:
-  provider: lambda
-  function_name: "thedasbot-prod-trigger"
-  region: "us-east-1"
-  role: "arn:aws:iam::054995062387:role/thedasbot-prod-us-east-1-lambdaRole"
-  runtime: "python3.7"
-  module_name: "handler"
-  handler_name: "trigger"
-  on:
-    branch: master

--- a/commands/trends_command.py
+++ b/commands/trends_command.py
@@ -1,7 +1,17 @@
-import matplotlib
 import requests
-import pandas as pd
-from pytrends.request import TrendReq
+try:
+    import matplotlib
+except Exception as err:
+    import traceback
+    print(f"Failed to import matplotlib!\n\n\t{str(err)}")
+    traceback.print_exc()
+try:
+    from pytrends.request import TrendReq
+except Exception as err:
+    import traceback
+    print(f"Failed to import pytrends!\n\n\t{str(err)}")
+    traceback.print_exc()
+
 from datetime import date, timedelta
 
 from .botcommand import BotCommand
@@ -77,7 +87,7 @@ class TrendsCommand(BotCommand):
     TOP_FLAG = 'top'
     DEFAULT_TIME_DELTA = '12m'
     DEFAULT_TRENDING_LOCATION = 'united_states'
-    FIGURE_NAME = 'figure.png'
+    TEMP_FIGURE_PATH = '/tmp/figure.png'
 
     @classmethod
     def get_help_text(cls):
@@ -139,9 +149,9 @@ class TrendsCommand(BotCommand):
         matplotlib.pyplot.gcf().subplots_adjust(bottom=0.15)
 
         fig = image.get_figure()
-        fig.savefig(self.FIGURE_NAME)
+        fig.savefig(self.TEMP_FIGURE_PATH)
 
-        self.handle_image_query(self.FIGURE_NAME)
+        self.handle_image_query(self.TEMP_FIGURE_PATH)
 
     def execute_trending_searches(self, location):
         try:

--- a/install_prod
+++ b/install_prod
@@ -1,0 +1,7 @@
+# Installs the dependencies for AWS lambda, which runs a distrubution of linux and requires different packages
+
+rm -r vendored
+python3 -m pip install -r requirements.txt -t vendored
+python3 -m pip install pytrends -t vendored --no-dependencies
+python3 -m pip install -r requirements-linux.txt --platform=manylinux1_x86_64 --only-binary=:all: -t vendored
+rm -r vendored/__pycache__

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+requests
+pytrends
+matplotlib

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,0 +1,4 @@
+pandas
+numpy
+matplotlib
+kiwisolver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
 requests
-lxml
-pandas
-pytrends
-matplotlib

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,6 @@ functions:
     handler: handler.trigger
     events:
       - http:
-          path: thedasbot
+          path: thedasbot-prod
           method: post
           cors: true


### PR DESCRIPTION
- numpy, pandas, and matplotlib that pytrends rely on requires packages specifically for Linux to work with AWS lambda so a custom installation procedure is needed
- Remove Travis deployment since dependencies are too large. Deployments to be done manually using serverless instead
- Travis and local builds install normally whereas the production build is installed differently via the `install_prod` script